### PR TITLE
클라이언트 로그인 관련 에러 수정

### DIFF
--- a/src/api/member.js
+++ b/src/api/member.js
@@ -10,7 +10,8 @@ async function doRegistration(member, success, fail) {
 }
 
 async function doLogin(member, success, fail) {
-    await local.post(`${api_name}/login`, JSON.stringify(member)).then(success).catch(fail);
+    const timeout = 1000;
+    await local.post(`${api_name}/login`, JSON.stringify(member), {timeout}).then(success).catch(fail);
 }
 
 async function findById(userid, success, fail) {

--- a/src/components/member/MemberForm.vue
+++ b/src/components/member/MemberForm.vue
@@ -32,14 +32,11 @@ async function onSubmit() {
     console.log("id", loginUser.value.userId);
     console.log("password", loginUser.value.userPass);
     
-    await userLogin(loginUser.value);
+    await userLogin(loginUser.value); 
 
-    // 동기 - 토큰 받아올 때까지 기다려
     let token = localStorage.getItem("accessToken");
     console.log("current Access toekn : ", token);
     
-    alert("로그인 성공");
-
     router.push("/");
 }
 

--- a/src/stores/member.js
+++ b/src/stores/member.js
@@ -60,7 +60,7 @@ export const useMemberStore = defineStore('memberStore', () => {
                 }
             },
             (error) => {
-                alert("로그인 실패");
+                alert("유효하지 않은 회원정보이거나 아이디 또는 비밀번호가 틀렸습니다.");
                 console.error(error);
             }
         );

--- a/src/stores/member.js
+++ b/src/stores/member.js
@@ -52,7 +52,6 @@ export const useMemberStore = defineStore('memberStore', () => {
                     console.log("localStorage에도 쿠키처럼 토큰 담았다");
                     localStorage.setItem("accessToken", accessToken);
                     localStorage.setItem("refreshToken", refreshToken);
-
                 } else {
                     console.log("로그인 실패했다");
                     isLogin.value = false;
@@ -61,6 +60,7 @@ export const useMemberStore = defineStore('memberStore', () => {
                 }
             },
             (error) => {
+                alert("로그인 실패");
                 console.error(error);
             }
         );


### PR DESCRIPTION
### 변경 내용
![image](https://github.com/junoade/tripJJ-frontend/assets/54317409/c473642e-dbbe-4cd8-b551-526a745f04b4)

### 1. 유효하지 않은 로그인 정보 입력해도 로그인 성공 팝업 뜨는 문제
> 해당 함수부에서 alert 하면 되지 않을까?
![image](https://github.com/junoade/tripJJ-frontend/assets/54317409/1d5b5283-ce04-4c0b-b121-fd7db3ca8d17)

- 로그인 실패할 때만 alert 뜨도록 변경
ps. caller 부분에서 callee 결과가 나오고 다음 caller의 실행흐름을 수행하도록 await 해야 함. 안 그러면 router.push() 호출부터 되고 alert이 다음에 뜰 수도

### 2. 로그인 요청 타임아웃 설정
- axios의 경우 default timeout은 2500ms.
- 1000ms로 변경